### PR TITLE
Utils class need not to be instantiated

### DIFF
--- a/src/de/espend/idea/android/utils/AndroidUtils.java
+++ b/src/de/espend/idea/android/utils/AndroidUtils.java
@@ -18,6 +18,9 @@ import java.util.List;
 
 public class AndroidUtils {
 
+    private AndroidUtils() {
+    }
+    
     @Nullable
     public static PsiFile findXmlResource(@Nullable PsiReferenceExpression referenceExpression) {
         if (referenceExpression == null) return null;


### PR DESCRIPTION
All methods are static. So we should add private constructor.