### PR TITLE
Util class doesn't need to be instantiated.

### DIFF
--- a/src/de/espend/idea/android/utils/AndroidViewUtil.java
+++ b/src/de/espend/idea/android/utils/AndroidViewUtil.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class AndroidViewUtil {
+    
+    private AndroidViewUtil() {
+    }
 
     public static Icon getCoreIconWithExtends(AndroidView view, PsiClass psiClass) {
 


### PR DESCRIPTION
All methods are static. So we should add private constructor.